### PR TITLE
Fix Multiple Client Issues

### DIFF
--- a/MainPlugin.cs
+++ b/MainPlugin.cs
@@ -14,7 +14,7 @@ namespace EnderIce2.SDRSharpPlugin
     {
         private SettingsPanel _controlPanel;
         private const LogLevel logLevel = LogLevel.Trace;
-        private const int discordPipe = -1;
+        private const int discordPipe = 0;
 
         private ISharpControl _control;
         private bool playedBefore;


### PR DESCRIPTION
With the Discord pipe set to -1, it will select whichever client was the most recently opened. For a lot of people, the first client they open is most likely the one they want to use Discord RPC with, hence why the pipe should be set to 0.

A settings option for picking the Discord pipe would also be beneficial for those who use multiple Discord clients on their computer.